### PR TITLE
Reduce bundle size by lazy-loading icons

### DIFF
--- a/entries.js
+++ b/entries.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/typed-array/entries');
+
+module.exports = parent;


### PR DESCRIPTION
To speed initial load and lower JS payload, SVG icons are now lazy-loaded. Updated Icon component to use dynamic imports and replaced direct inline imports across components, reducing initial bundle size by ~12%.